### PR TITLE
Add radius as a direction and search option

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,26 @@ placesFurtherToNorth.length // 21404 places are further to north than Palo Alto
 
 ----
 
+### Search by meter radius from location
+
+```typescript
+const inRadius = ZipMonster.find({
+    location: {
+        latitude: {
+            value: PaloAlto.location!.latitude,
+            direction: 'radius'
+        },
+        longitude: {
+            value: PaloAlto.location!.longitude,
+            direction: "radius"
+        },
+        radius: 50 * 1000 // 50 km
+    }
+})
+```
+
+----
+
 ### Combine search parameters
 
 You can also combine search parameters with each other:

--- a/package.json
+++ b/package.json
@@ -9,12 +9,13 @@
         "test": "rm -rf dist && jest --passWithNoTests"
     },
     "dependencies": {
+        "geolib": "^3.3.3"
     },
     "devDependencies": {
-        "typescript": "4.1.2",
+        "@types/jest": "27.0.2",
         "@types/node": "17.0.3",
         "jest": "27.3.0",
-        "@types/jest": "27.0.2",
-        "ts-jest": "27.0.7"
+        "ts-jest": "27.0.7",
+        "typescript": "4.1.2"
     }
 }

--- a/src/engine/find-zip.ts
+++ b/src/engine/find-zip.ts
@@ -1,6 +1,7 @@
 import store from "../data/store";
 import { isZipInformation, ZipInformation } from "../data/models/zip-information";
 import { isZipType, ZipType } from "../types/zip-type";
+import { isPointWithinRadius } from 'geolib';
 
 export const findZip = (filter?: ZipFilter): ZipInformation[] => {
     if (!filter) {
@@ -36,6 +37,16 @@ export const findZip = (filter?: ZipFilter): ZipInformation[] => {
         });
     }
 
+    const applyRadiusFilter = (latitude: number, longitude: number, radius: number) => {
+        result = result.filter(el => {
+            return isPointWithinRadius(
+                    { latitude: el.location!.latitude, longitude: el.location!.longitude },
+                    { latitude, longitude },
+                    radius
+                )
+        })
+    }
+
     const applyRegularExpressionFilter = (filter: RegExp, stringFieldName: keyof ZipInformation) => {
         const regularExpression = filter;
         result = result.filter(el => regularExpression.test(el[stringFieldName] as string));
@@ -48,36 +59,40 @@ export const findZip = (filter?: ZipFilter): ZipInformation[] => {
         if (latitudeRequirement || longitudeRequirement) {
             result = result.filter(el => el.location !== undefined);
 
-            if (latitudeRequirement) {
-                result = result.filter(el => {
-                    switch (latitudeRequirement.direction) {
-                        case "to-north": {
-                            return el.location!.latitude > latitudeRequirement.value;
+            if (latitudeRequirement && latitudeRequirement.direction === 'radius' && longitudeRequirement && latitudeRequirement.direction === 'radius' && filter.radius) {
+                applyRadiusFilter(latitudeRequirement.value, longitudeRequirement.value, filter.radius)
+            } else {
+                if (latitudeRequirement) {
+                    result = result.filter(el => {
+                        switch (latitudeRequirement.direction) {
+                            case "to-north": {
+                                return el.location!.latitude > latitudeRequirement.value;
+                            }
+                            case "to-south": {
+                                return el.location!.latitude < latitudeRequirement.value;
+                            }
+                            case "here": {
+                                return el.location!.latitude === latitudeRequirement.value;
+                            }
                         }
-                        case "to-south": {
-                            return el.location!.latitude < latitudeRequirement.value;
-                        }
-                        case "here": {
-                            return el.location!.latitude === latitudeRequirement.value;
-                        }
-                    }
-                });
-            }
+                    });
+                }
 
-            if (longitudeRequirement) {
-                result = result.filter(el => {
-                    switch (longitudeRequirement.direction) {
-                        case "to-east": {
-                            return el.location!.longitude > longitudeRequirement.value;
+                if (longitudeRequirement) {
+                    result = result.filter(el => {
+                        switch (longitudeRequirement.direction) {
+                            case "to-east": {
+                                return el.location!.longitude > longitudeRequirement.value;
+                            }
+                            case "to-west": {
+                                return el.location!.longitude < longitudeRequirement.value;
+                            }
+                            case "here": {
+                                return el.location!.longitude === longitudeRequirement.value;
+                            }
                         }
-                        case "to-west": {
-                            return el.location!.longitude < longitudeRequirement.value;
-                        }
-                        case "here": {
-                            return el.location!.longitude === longitudeRequirement.value;
-                        }
-                    }
-                });
+                    });
+                }
             }
         }
     }
@@ -197,7 +212,7 @@ const is_zipSearch_stringFlexibleFilter = (obj: any): obj is ZipSearch_StringFle
 
 export interface ZipSearch_LocationFlexibleFilter_LatitudeCondition {
     value: number,
-    direction: "to-north" | "to-south" | "here"
+    direction: "to-north" | "to-south" | "here" | "radius"
 }
 
 const is_zipSearch_locationFlexibleFilter_latitudeCondition = (obj: any): obj is ZipSearch_LocationFlexibleFilter_LatitudeCondition => {
@@ -214,7 +229,7 @@ const is_zipSearch_locationFlexibleFilter_latitudeCondition = (obj: any): obj is
 
 export interface ZipSearch_LocationFlexibleFilter_LongitudeCondition {
     value: number,
-    direction: "to-east" | "to-west" | "here"
+    direction: "to-east" | "to-west" | "here" | "radius"
 }
 
 const is_zipSearch_locationFlexibleFilter_longitudeCondition = (obj: any): obj is ZipSearch_LocationFlexibleFilter_LongitudeCondition => {
@@ -231,7 +246,8 @@ const is_zipSearch_locationFlexibleFilter_longitudeCondition = (obj: any): obj i
 
 export interface ZipSearch_LocationFlexibleFilter {
     latitude?: ZipSearch_LocationFlexibleFilter_LatitudeCondition,
-    longitude?: ZipSearch_LocationFlexibleFilter_LongitudeCondition
+    longitude?: ZipSearch_LocationFlexibleFilter_LongitudeCondition,
+    radius?: number
 }
 
 const is_zipSearch_locationFlexibleFilter = (obj: any): obj is ZipSearch_LocationFlexibleFilter => {
@@ -242,7 +258,8 @@ const is_zipSearch_locationFlexibleFilter = (obj: any): obj is ZipSearch_Locatio
                 : true,
             "longitude" in obj
                 ? is_zipSearch_locationFlexibleFilter_longitudeCondition(obj["longitude"])
-                : true
+                : true,
+            (obj?.latitude?.direction === 'radius' || obj?.longitude?.direction === 'radius') && obj.radius   
         ];
         return !requirements.includes(false);
     } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1187,6 +1187,11 @@ gensync@^1.0.0-beta.2:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
+geolib@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/geolib/-/geolib-3.3.3.tgz#17f5a0dcdc0b051bd631b66f7131d2c14c54a15b"
+  integrity sha512-YO704pzdB/8QQekQuDmFD5uv5RAwAf4rOUPdcMhdEOz+HoPWD0sC7Qqdwb+LAvwIjXVRawx0QgZlocKYh8PFOQ==
+
 get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"


### PR DESCRIPTION
This pull request adds `direction` `'radius'` as an option in location searches for searching for zip codes within a certain distance (in meters) from a provided location. README has been updated to reflect this new option.